### PR TITLE
Steady scheduling of bump mitigation

### DIFF
--- a/src/main/java/frc/robot/automations/BumpMitigation.java
+++ b/src/main/java/frc/robot/automations/BumpMitigation.java
@@ -111,7 +111,7 @@ public class BumpMitigation implements Runnable {
 				|| this.withinBounds(dynamicBoxTopRed, robotPose.getTranslation())
 				|| this.withinBounds(dynamicBoxBottomRed, robotPose.getTranslation())
 			)
-			&& this.drive.rotationalSubsystem.getCurrentCommand() == null
+			&& (this.drive.rotationalSubsystem.getCurrentCommand() == null || this.drive.rotationalSubsystem.getCurrentCommand() == this.command)
 		);
 
 		if (this.edgeDetector.risingEdge() && !this.command.isScheduled()) {


### PR DESCRIPTION
Bump mitigation used to constantly schedule and cancel each tick. Now it schedules and doesn't cancel itself just because it is scheduled.